### PR TITLE
Update package validation baseline to 1.1.3

### DIFF
--- a/src/Pure.Primitives.Switches/Pure.Primitives.Switches.csproj
+++ b/src/Pure.Primitives.Switches/Pure.Primitives.Switches.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <IsAotCompatible>true</IsAotCompatible>
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>1.1.2</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>1.1.3</PackageValidationBaselineVersion>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>Pure.Primitives.Switches</PackageId>


### PR DESCRIPTION
Bump `PackageValidationBaselineVersion` from `1.1.2` to `1.1.3` following the successful publish.